### PR TITLE
chore: set commitlint scope enums

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,3 +1,16 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'scope-enum': [2, 'always', [
+      'toDecimal',
+      'fromDecimal',
+      'hexToUtf8',
+      'utf8ToHex',
+      'toDate',
+      'fromDate',
+      'removeNumericKeys',
+      'parseRevert',
+    ]],
+    'scope-case': [2, 'always', 'camel-case'],
+  },
 };


### PR DESCRIPTION
for this project i think it makes sense to limit the scope's for commits to the utility methods themselves.

scope is still optional but if commits are focused on a specific module, it's informative to include it for the sake of the changelog